### PR TITLE
fix: update array index to correctly parse app version

### DIFF
--- a/internal/models/playstore.go
+++ b/internal/models/playstore.go
@@ -49,7 +49,7 @@ func NewPlaystoreData(packageID string, data []interface{}) *PlaystoreData {
 	}
 
 	version := ""
-	if val, ok := getAttributeFromData[map[string]interface{}](data, 1, 2, 112)["141"]; ok && val != nil {
+	if val, ok := getAttributeFromData[map[string]interface{}](data, 1, 2, 103)["141"]; ok && val != nil {
 		if v, ok := val.([]interface{}); ok {
 			version = getAttributeFromData[string](v, 0, 0, 0)
 		}


### PR DESCRIPTION
## Description
Google Play Store recently updated its underlying web response structure, which broke the app version extraction. The data map containing the version string under key `"141"` has shifted from index `112` to `103` within the `data[1][2]` array. 

Because of this shift, the primary extraction was failing, and the existing fallback at index `140` was also no longer catching the version, resulting in an empty version string being returned.

## Changes Made
* Updated index in `getAttributeFromData` from `112` to `103` to reflect the new Play Store array structure.

## Related Code
```go
// Before
if val, ok := getAttributeFromData[map[string]interface{}](data, 1, 2, 112)["141"]; ok && val != nil {

// After
if val, ok := getAttributeFromData[map[string]interface{}](data, 1, 2, 103)["141"]; ok && val != nil {